### PR TITLE
Remove trailing field separator on each row.

### DIFF
--- a/Angular2-csv.ts
+++ b/Angular2-csv.ts
@@ -114,7 +114,7 @@ export class Angular2Csv {
   			row += this.formartData(this.data[i][index]) + this._options.fieldSeparator;;
   		}
 
-  		row.slice(0, row.length - 1);
+			row = row.slice(0, -1);
   		this.csv += row + CsvConfigConsts.EOL;
   	}
   }


### PR DESCRIPTION
The resulting csv file has an extra field separator on each body row. 
```
col1,col2,col3
111,222,333,
111,222,333,
111,222,333,
```
Header row does not have this problem because getHeaders() uses 
`row = row.slice(0, -1);`
while getBody() does it incorrectly
`row.slice(0, row.length - 1);`

This commit modifies the getBody() to do it the same way as getHeaders().
```
col1,col2,col3
111,222,333
111,222,333
111,222,333
```

