### PR TITLE
Adds overrideSystemSeparator option

### DIFF
--- a/Angular2-csv.ts
+++ b/Angular2-csv.ts
@@ -7,6 +7,7 @@ export interface Options {
 	showTitle: boolean;
 	title: string;
 	useBom: boolean;
+	overrideSystemSeparator: boolean;
 }
 
 export class CsvConfigConsts {
@@ -22,6 +23,7 @@ export class CsvConfigConsts {
 	public static DEFAULT_FILENAME = 'mycsv.csv';
 	public static DEFAULT_SHOW_LABELS = false;
 	public static DEFAULT_USE_BOM = true;
+	public static DEFAULT_OVERRIDE_SYSTEM_SEPARATOR = false;
 
 }
 
@@ -33,7 +35,8 @@ export const ConfigDefaults: Options = {
 	showLabels: 				CsvConfigConsts.DEFAULT_SHOW_LABELS,
 	showTitle:					CsvConfigConsts.DEFAULT_SHOW_TITLE,
 	title: 							CsvConfigConsts.DEFAULT_TITLE,
-	useBom:					CsvConfigConsts.DEFAULT_USE_BOM
+	useBom:					CsvConfigConsts.DEFAULT_USE_BOM,
+	overrideSystemSeparator:	CsvConfigConsts.DEFAULT_OVERRIDE_SYSTEM_SEPARATOR
 };
 export class Angular2Csv {
 
@@ -63,6 +66,10 @@ export class Angular2Csv {
 	private generateCsv(): void {
 		if(this._options.useBom) {
 			this.csv += CsvConfigConsts.BOM;
+		}
+		
+		if(this._options.overrideSystemSeparator) {
+			this.csv += 'sep=' + this._options.fieldSeparator + CsvConfigConsts.EOL;
 		}
 
 		if(this._options.showTitle) {

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ new Angular2Csv(data, 'My Report');
 | **showLabels** | false      | If provided, would use this attribute to create a header row |
 | **showTitle** | false      |   |
 | **useBom** | true      | If true, adds a BOM character at the start of the CSV |
+| **overrideSystemSeparator** | false   | If true, it specifies the separator inside the CSV file. This allows Excel to override user's system regional settings and always display the file correctly.
 
 
 **Example**
@@ -65,7 +66,8 @@ new Angular2Csv(data, 'My Report');
     decimalseparator: '.',
     showLabels: true, 
     showTitle: true,
-    useBom: true
+    useBom: true,
+    overrideSystemSeparator: true
   };
 
   Angular2Csv(data, filename, options);


### PR DESCRIPTION
If set to true, a `sep=<fieldSeparator>` line will be added at the start of the CSV file, allowing Excel to recognize what filed separator is used inside of the CSV file, and override the system's regional settings. This ensures that the file will be always displayed correctly.