### PR TITLE
chore(package): update angular to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "typings": "./Angular2-csv.d.ts",
   "homepage": "https://github.com/javiertelioz/angular2-csv#readme",
   "devDependencies": {
-    "@angular/common": "^2.4.2||^4.0.0",
-    "@angular/core": "^2.4.2||^4.0.0",
-    "@angular/http": "^2.4.2||^4.0.0",
-    "@angular/platform-browser": "^2.4.2||^4.0.0",
+    "@angular/common": "^2.4.2||^4.0.0||^5.0.0",
+    "@angular/core": "^2.4.2||^4.0.0||^5.0.0",
+    "@angular/http": "^2.4.2||^4.0.0||^5.0.0",
+    "@angular/platform-browser": "^2.4.2||^4.0.0||^5.0.0",
     "@types/jasmine": "^2.5.46",
     "@types/js-base64": "^2.1.3",
     "awesome-typescript-loader": "^3.1.2",
@@ -55,8 +55,8 @@
     "zone.js": "~0.7.2||~0.8.5"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0||^4.0.0",
-    "@angular/http": "^2.0.0||^4.0.0",
+    "@angular/core": "^2.0.0||^4.0.0||^5.0.0",
+    "@angular/http": "^2.0.0||^4.0.0||^5.0.0",
     "rxjs": "^5.0.0"
   }
 }


### PR DESCRIPTION
It also sets all angular dependencies to the new version of angular: ^5.0.0, in order to avoid the following warning:
"npm WARN angular2-csv@0.2.5 requires a peer of @angular/http@^2.0.0||^4.0.0 but none was installed."