### PR TITLE
changes to set multiple rows of header

### DIFF
--- a/Angular2-csv.ts
+++ b/Angular2-csv.ts
@@ -103,15 +103,16 @@ export class Angular2Csv {
 	 * Create Headers
 	 */
 	getHeaders(): void {
-		if (this._options.headers.length > 0) {
-            let row = "";
-            for (var column of this._options.headers) {
-                row += column + this._options.fieldSeparator;
+		this._options.headers.forEach( value => {
+            if(value.length > 0) {
+                let row = "";
+                for (var column of value) {
+                    row += column + this._options.fieldSeparator;
+                }
+                row = row.slice(0, -1);
+                this.csv += row + CsvConfigConsts.EOL;
             }
-
-            row = row.slice(0, -1);
-            this.csv += row + CsvConfigConsts.EOL;
-        }
+        });
   }
   /**
    * Create Body


### PR DESCRIPTION
Header names can be set in **multiple rows** which is helpful in many scenarios. 

example -
const options = {
                            fieldSeparator: ',',
                            quoteStrings: '"',
                            decimalseparator: '.',
                            showLabels: true,
                            showTitle: false,
                            headers: [
                                ['November'],
                                ['Store Name'],
                                ['Spent', 'Saved'']
                            ]
                            };