### PR TITLE
Update package.json for Angular 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-csv",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Helper library for create CSV file in Angular 2",
   "repository": {
     "type": "git",
@@ -31,10 +31,10 @@
   "typings": "./Angular2-csv.d.ts",
   "homepage": "https://github.com/javiertelioz/angular2-csv#readme",
   "devDependencies": {
-    "@angular/common": "^2.4.2||^4.0.0",
-    "@angular/core": "^2.4.2||^4.0.0",
-    "@angular/http": "^2.4.2||^4.0.0",
-    "@angular/platform-browser": "^2.4.2||^4.0.0",
+    "@angular/common": "^2.4.2||^4.0.0||^5.0.0||^6.0.0",
+    "@angular/core": "^2.4.2||^4.0.0||^5.0.0||^6.0.0",
+    "@angular/http": "^2.4.2||^4.0.0||^5.0.0||^6.0.0",
+    "@angular/platform-browser": "^2.4.2||^4.0.0||^5.0.0||^6.0.0",
     "@types/jasmine": "^2.5.46",
     "@types/js-base64": "^2.1.3",
     "awesome-typescript-loader": "^3.1.2",
@@ -49,14 +49,14 @@
     "karma-webpack": "^2.0.3",
     "phantomjs-prebuilt": "^2.1.7",
     "reflect-metadata": "^0.1.10",
-    "rxjs": "^5.0.0",
+    "rxjs": "^5.0.0||^6.0.0",
     "typescript": "~2.1.5",
     "webpack": "^2.3.1",
     "zone.js": "~0.7.2||~0.8.5"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0||^4.0.0",
-    "@angular/http": "^2.0.0||^4.0.0",
-    "rxjs": "^5.0.0"
+    "@angular/core": "^2.0.0||^4.0.0||^5.0.0||^6.0.0",
+    "@angular/http": "^2.0.0||^4.0.0||^5.0.0||^6.0.0",
+    "rxjs": "^5.0.0||^6.0.0"
   }
 }


### PR DESCRIPTION
Updating package.json to support Angular 6.

This package has no specific code that would conflict with Angular 6 but currently does conflict with Angular 6 updates due to not supporting Angular 6 in its "Peer Dependencies" list. This merge would fix that so that Angular 6 upgrade scripts would work seamlessly with this package. 